### PR TITLE
Improve watchman docs

### DIFF
--- a/guides/basic-use/index.md
+++ b/guides/basic-use/index.md
@@ -20,15 +20,17 @@ This will make the `ember` command available throughout your project folders. Th
 
 ### Additional steps for Mac and Linux users
 
-Mac and Linux users may need to install [Watchman](https://facebook.github.io/watchman/). Watchman helps correct for some buggy and inefficient file watching behavior. Do not use the `npm` package by the same name.
+For Mac and Linux users we recommend installing [Watchman](https://facebook.github.io/watchman/). Watchman helps correct for some buggy and inefficient file watching behavior. Do not use the `npm` package by the same name.
 
-Mac users cann install via [Homebrew](http://brew.sh/):
+Mac users cann install via [Homebrew](https://brew.sh/):
 
 ```bash
 brew install watchman
 ```
 
 Linux users should follow the steps on the [Watchman](https://facebook.github.io/watchman/) website to build from the source.
+
+If Watchman is not installed, a notice is displayed when invoking various commands ("Could not start watchman"). It's safe to ignore this message. However, file-watching won't be as smooth as it is with Watchman.
 
 ### Installing for Windows
 


### PR DESCRIPTION
Only a few changes (the current text is good):

- Replaced 'may need' with 'we recommend'
- Updated synced 'missing watchman' message, to make this page show up in google results (https://github.com/chrmod/watch-detector/blob/master/lib/index.js#L256)

There are a few more things mentioned in the [old docs](https://ember-cli.com/user-guide/#watchman), but I'm not sure if they're worth moving over, they seem like pretty auxiliary things. If included, it would be neat to fold them into a details/summary block (if the docs site support that).
```
<details><summary>Debugging & Advanced</summary><!-- more details here --></details>
```